### PR TITLE
Avoid generating dark user color

### DIFF
--- a/markut.go
+++ b/markut.go
@@ -1289,6 +1289,10 @@ var Subcommands = map[string]Subcommand{
 					var color string
 					if cursor != nil {
 						color = cursor.(string)
+						// Avoid generating dark user color
+						if color == "#000000" {
+							color = "#0000FF"
+						}
 					} else {
 						// Taken from https://discuss.dev.twitch.com/t/default-user-color-in-chat/385
 						// I don't know if it's still accurate, but I don't care, we just need some sort of


### PR DESCRIPTION
Dark user color is barely readable when the background is dark.

```
./markut twitch-chat-download -videoID 2601051402 > foo.csv
```
For example, the color of user `c_rdain` is `#000000` in this live. 
https://www.youtube.com/watch?v=3YXxsEWMldo&t=2861s